### PR TITLE
Determine GIT_WORK_TREE using LOCAL_REPO

### DIFF
--- a/movein
+++ b/movein
@@ -162,10 +162,10 @@ EOF
 git_work_tree() {
     local TEMP_REPO
     TEMP_REPO=$1
-    GIT_WORK_TREE=../../
+    GIT_WORK_TREE=../
 
-    while [ "${TEMP_REPO#*/}" != "$TEMP_REPO" ]; do
-        TEMP_REPO="${TEMP_REPO#*/}"
+    while [ "${TEMP_REPO%/*}" != "$HOME" ]; do
+        TEMP_REPO="${TEMP_REPO%/*}"
         GIT_WORK_TREE="../$GIT_WORK_TREE"
     done
 }
@@ -210,7 +210,7 @@ add() {
             trap "unset GIT_DIR; unset GIT_WORK_TREE; rm -rf $LOCAL_REPO" 0
             mkdir -p "$LOCAL_REPO"
             export GIT_DIR="$LOCAL_REPO"
-            git_work_tree "$REPO_NAME"
+            git_work_tree "$LOCAL_REPO"
             git init --bare
             git remote add origin $REPO_URL
             git config branch.master.remote origin
@@ -275,7 +275,7 @@ new() {
         fi
 
         export GIT_DIR="$LOCAL_REPO"
-        git_work_tree "$REPO_NAME"
+        git_work_tree "$LOCAL_REPO"
         git init --bare
         git remote add origin $REPO_URL
         git config branch.master.remote origin


### PR DESCRIPTION
Using simply the REPO_NAME to determine the value for GIT_WORK_TREE required
that LOCAL_REPOS was stored directly under the home directory.  If it is
stored in a sub-directory of $HOME (e.g., ~/.local/movein), then the relative
path will be incorrect.

Instead, use the full path to the repo (LOCAL_REPO) as the basis for
determining how many directory traversals are required.

Signed-off-by: James McCoy vega.james@gmail.com
