### PR TITLE
Support RedHat-based distros

### DIFF
--- a/movein
+++ b/movein
@@ -152,7 +152,7 @@ CREATE_REMOTE=$CREATE_REMOTE
 EOF
 
     if [ ! -d "$LOCAL_REPOS" ]; then
-       mkdir -p "$LOCAL_REPOS"
+        mkdir -p "$LOCAL_REPOS"
     fi
 
     mr -c "$MRCONFIG" config DEFAULT include="cat /usr/share/mr/git-fake-bare"

--- a/movein
+++ b/movein
@@ -155,7 +155,13 @@ EOF
         mkdir -p "$LOCAL_REPOS"
     fi
 
-    mr -c "$MRCONFIG" config DEFAULT include="cat /usr/share/mr/git-fake-bare"
+    if [ -f /usr/share/mr/lib/git-fake-bare ] ; then
+        GIT_FAKE_BARE="/usr/share/mr/lib/git-fake-bare"
+    else
+        GIT_FAKE_BARE="/usr/share/mr/git-fake-bare"
+    fi
+
+    mr -c "$MRCONFIG" config DEFAULT include="cat $GIT_FAKE_BARE"
 
 }
 


### PR DESCRIPTION
git-fake-bare is shipped in a different location on RedHat-based distros. This patch checks if it exists and falls back to the previous default.
